### PR TITLE
Whitelist hyp3lib.get_orb warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.2](https://github.com/asfadmin/hyp3-proc-lib/compare/v1.0.1...v1.0.2)
+
+### Changed
+* Whitelist warning messages from `hyp3lib.get_orb` for `hyp3lib` >= v1.4.1
+
 ## [v1.0.1](https://github.com/asfadmin/hyp3-proc-lib/compare/v1.0.0...v1.0.1)
 
 ### Fixed

--- a/hyp3proclib/__init__.py
+++ b/hyp3proclib/__init__.py
@@ -208,7 +208,7 @@ def setup(name, cli_args=None, airgap=False, sci_version='Unknown'):
             cfg['jers_whitelist'] = jwl
 
         cfg['process_ids'] = get_process_id_dict()
-   
+
     if is_config('general', 'verbose'):
         args.verbose = True
     setup_logger(cfg, args.verbose)
@@ -292,6 +292,7 @@ def contains_allowable_error(s):
         'raise FileException(error)',
         'S3RegionRedirector.redirect_from_error',
         'error is',
+        'Error encountered fetching',
     ]
 
     return any([i in s for i in l])
@@ -819,7 +820,7 @@ def upload_product(product_path, cfg, conn, browse_path=None, skip_notify=False)
         pathFrame = findPathFrame(cfg['granule'])
     else:
         pathFrame = {"path": None, "frame": None}
-    
+
     cfg['filename'] = os.path.basename(product_path)
 
     res = query_database(conn, "select id, name, url, browse_url from products where local_queue_id = %(local_queue_id)s",
@@ -1199,8 +1200,8 @@ def findPathFrame(granule):
     req = Request(url, headers={'content-type': 'application/json'})
     response = urlopen(req)
     decoded = response.read().decode('utf8')
-    parsed_json = json.loads(decoded)    
-    
+    parsed_json = json.loads(decoded)
+
     if(parsed_json[0]):
         path = parsed_json[0][1]['track']
         frame = parsed_json[0][1]['frameNumber']
@@ -1383,7 +1384,7 @@ def update_queue_status(conn, cfg, new_status, msg=None, queue_id=None):
         sql = "update local_queue set status = %(status)s, message = %(msg)s where id = %(id)s"
         query_database(
             conn, sql, {'status': new_status, 'msg': msg, 'id': queue_id}, commit=True)
- 
+
     if cfg['proc_name'] != "notify":
         update_instance_record(cfg, conn)
 
@@ -1401,16 +1402,16 @@ def zip_dir(path, zip_name):
         mode = 'a'
     else:
         log.info('Creating zip {0} from folder {1}'.format(zip_name, path))
-    
+
     ziph = zipfile.ZipFile(
         zip_name, mode, zipfile.ZIP_DEFLATED, allowZip64=True)
-    
+
     for root, dirs, files in os.walk(path):
         for f in files:
             pathToRead = os.path.join(root, f)
             archivePath = os.path.relpath(os.path.join(root, f), os.path.join(path, ".."))
             ziph.write(pathToRead, archivePath)
-            
+
     ziph.close()
     return True
 


### PR DESCRIPTION
## Description of this release

Error "handling" in hyp3proclib is masking true errors for `hyp3lib` >= 1.4.1 due to warning messages that look like:

```
autorift_proc_pair: 2020-09-15 19:12:54,711 - root - WARNING - Error encountered fetching AUX_POEORB orbit file from ESA; looking for another
```
This whitelist those style of errors. 

### Developer checklist

- [x] Assigned a reviewer
  <!-- NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
   changes which you'd like reviewed. Do not open a pull request to update a feature or personal
   branch -- simply merge with `git`.
   -->
- [x] Indicated the level of changes to this package by affixing one of these labels:
  * ~"major" -- Major changes to the API that may break current workflows
  * ~"minor" -- Minor changes to the API that do not break current workflows 
  * **~"patch" -- Patches and bugfixes for the current version that do not break current workflows**
  * ~"bumpless" -- Changes to documentation, CI/CD pipelines, etc. that don't affect the software's version 

- [ ] ~~(If applicable) Updated the dependencies and indicated any downstream changes that are required~~

- [x] Updated the CHANGELOG.md
- [ ] ~~Added/updated documentation for these changes~~
- [ ] ~~Added/updated tests for these changes~~

### Reviewer checklist

- [ ] Are all the Checks passing?
- [ ] Have all dependencies been updated and required changes merged downstream?
- [ ] Is the level of changes labeled appropriately?
- [ ] Are all the changes described appropriately in the changelog?
- [ ] Has the documentation been adequately updated?
- [ ] Are the test adequate?